### PR TITLE
Add micro QR range printing script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "@sealsystems/ipp": "^2.7.7",
     "pngparse": "^2.0.1",
     "util": "^0.12.4",
-    "pngjs": "^7.0.0"
+    "pngjs": "^7.0.0",
+    "bwip-js": "^2.0.9"
   },
   "devDependencies": {
     "@types/node": "^16.11.7",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "@sealsystems/ipp": "^2.7.7",
     "pngparse": "^2.0.1",
-    "util": "^0.12.4"
+    "util": "^0.12.4",
+    "pngjs": "^7.0.0"
   },
   "devDependencies": {
     "@types/node": "^16.11.7",

--- a/samples/print-microqr-range.js
+++ b/samples/print-microqr-range.js
@@ -1,0 +1,46 @@
+const bwipjs = require('bwip-js');
+const { printBuffer } = require('../dist/index.js');
+
+async function createMicroQR(text) {
+    return bwipjs.toBuffer({
+        bcid: 'microqrcode',
+        text: text,
+        scale: 4,
+    });
+}
+
+(async() => {
+    const [ , , startArg, endArg ] = process.argv;
+    if (!startArg) {
+        console.error('Usage: node print-microqr-range.js <start> [end]');
+        process.exit(1);
+    }
+
+    const start = parseInt(startArg, 10);
+    const end = endArg ? parseInt(endArg, 10) : start;
+
+    if (Number.isNaN(start) || Number.isNaN(end) || end < start) {
+        console.error('Invalid range provided.');
+        process.exit(1);
+    }
+
+    const printerUrl = 'http://192.168.178.71:631/ipp/print';
+    const tapeWidth = 12;
+
+    for (let i = start; i <= end; i += 1) {
+        const qr = await createMicroQR(String(i));
+        await printBuffer(printerUrl, qr, {
+            tapeWidth,
+            halfCut: true,
+            highResolution: false,
+        });
+    }
+
+    // Final full cut
+    const blankPng = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAC0lEQVR42mP8/x8AAwMCAK+X8VQAAAAASUVORK5CYII=', 'base64');
+    await printBuffer(printerUrl, blankPng, {
+        tapeWidth,
+        halfCut: false,
+        highResolution: false,
+    });
+})();

--- a/samples/print-microqr-range.js
+++ b/samples/print-microqr-range.js
@@ -5,8 +5,12 @@ const { printBuffer } = require('../dist/index.js');
 async function createMicroQR(text) {
     return bwipjs.toBuffer({
         bcid: 'microqrcode',
-        text: text,
+        text,
         scale: 4,
+        includetext: true,
+        textxalign: 'center',
+        textfont: 'OCR-B',
+        textsize: 8,
     });
 }
 

--- a/samples/print-microqr-range.js
+++ b/samples/print-microqr-range.js
@@ -1,4 +1,5 @@
 const bwipjs = require('bwip-js');
+const { PNG } = require('pngjs');
 const { printBuffer } = require('../dist/index.js');
 
 async function createMicroQR(text) {
@@ -37,7 +38,11 @@ async function createMicroQR(text) {
     }
 
     // Final full cut
-    const blankPng = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAC0lEQVR42mP8/x8AAwMCAK+X8VQAAAAASUVORK5CYII=', 'base64');
+    const blankPng = (() => {
+        const png = new PNG({ width: 1, height: 1 });
+        png.data.fill(255); // white pixel with full alpha
+        return PNG.sync.write(png);
+    })();
     await printBuffer(printerUrl, blankPng, {
         tapeWidth,
         halfCut: false,


### PR DESCRIPTION
## Summary
- add `print-microqr-range.js` example for printing a range of micro QR codes

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_687fb8eb88dc8326ba74834025b308f7