### PR TITLE
Add thorough tests with IPP mocks

### DIFF
--- a/dist/brother.d.ts
+++ b/dist/brother.d.ts
@@ -1,0 +1,14 @@
+export interface PrintOptions {
+    /** default: true */
+    autoCut?: boolean;
+    /** default: 128 */
+    blackwhiteThreshold?: number;
+    /** default: true */
+    halfCut?: boolean;
+    /** default: false */
+    highResolution?: boolean;
+    /** default: 12  */
+    tapeWidth?: 12 | 18 | 24;
+}
+export declare const printPngFile: (printerUrl: string, filename: string, options?: PrintOptions) => Promise<any>;
+export declare const printBuffer: (printerUrl: string, buffer: Buffer, options?: PrintOptions) => Promise<any>;

--- a/dist/brother.js
+++ b/dist/brother.js
@@ -1,0 +1,171 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.printBuffer = exports.printPngFile = void 0;
+const ipp_1 = __importDefault(require("@sealsystems/ipp"));
+const node_util_1 = __importDefault(require("node:util"));
+const pngparse_1 = __importDefault(require("pngparse"));
+const parseFile = node_util_1.default.promisify(pngparse_1.default.parseFile);
+const parse = node_util_1.default.promisify(pngparse_1.default.parse);
+function wait(time) {
+    return new Promise(resolve => setTimeout(resolve, time));
+}
+function getConfigByte(value, position) {
+    return ((value ? 1 : 0) << position);
+}
+function convertToBlackAndWhiteMatrix(image, threshold) {
+    const rows = [];
+    for (let y = 0; y < image.height; y++) {
+        const cols = [];
+        for (let x = 0; x < image.width; x++) {
+            let pos = x + image.width * y;
+            pos = pos * image.channels;
+            // 1 channel : grayscale
+            // 2 channels: grayscale + alpha
+            // 3 channels: RGB
+            // 4 channels: RGBA
+            switch (image.channels) {
+                case 1:
+                    cols.push(image.data[pos] < threshold ? 1 : 0);
+                    break;
+                case 2:
+                    cols.push((image.data[pos] * image.data[pos + 1] / 255) < threshold ? 1 : 0);
+                    break;
+                case 3:
+                    cols.push((0.21 * image.data[pos] + 0.72 * image.data[pos + 1] + 0.07 * image.data[pos + 2]) < threshold ? 1 : 0);
+                    break;
+                case 4:
+                    cols.push(((0.21 * image.data[pos] + 0.72 * image.data[pos + 1] + 0.07 * image.data[pos + 2]) * image.data[pos + 3] / 255) < threshold ? 1 : 0);
+                    break;
+            }
+        }
+        rows.push(cols);
+    }
+    return {
+        height: image.height,
+        width: image.width,
+        data: rows,
+    };
+}
+function convertToLabelBuffer(pixelMatrix, options) {
+    const data = [
+        // Invalidate
+        Buffer.alloc(400),
+        // Initialize
+        Buffer.from([0x1B, 0x40]),
+        // Switch to Raster Mode
+        Buffer.from([0x1B, 0x69, 0x61, 0x01]),
+        // Print information command — Sets tape width
+        // 0x02 Media type
+        // 0x04 Media width
+        // 0x08 Media length
+        // 0x40 Priority given to print quality(Not used)
+        // 0x80 Printer recovery always on
+        Buffer.from([0x1B, 0x69, 0x7A, 0x84, 0x00, options.tapeWidth, 0x00, 0xAA, 0x02, 0x00, 0x00, 0x00, 0x00]),
+        // Various mode settings - Auto Cut
+        Buffer.from([0x1B, 0x69, 0x4D, 0x40]),
+        // Cut per label setting - 0x01 -> each label
+        Buffer.from([0x1B, 0x69, 0x41, 0x01]),
+        // Advanced Setting Mode
+        // 2bit half-cut, 3bit no chain printing, 4bit special tape, 6bit high-res, 7bit mirror
+        Buffer.from([0x1B, 0x69, 0x4B, getConfigByte(options.halfCut, 2) | getConfigByte(true, 3) | getConfigByte(!options.autoCut, 4) | getConfigByte(options.highResolution, 6)]),
+        // Margin feed amount - 2mm --> 28 dots on high-res otherwise 14 dots
+        Buffer.from([0x1B, 0x69, 0x64, 14 * (options.highResolution ? 2 : 1), 0x00]),
+        // Enable TIFF - Compression
+        // ..on P750W seems like has an issue with 0x1A command and doesn't cut or return back to idle mode
+        // unless TIFF compression is enabled.
+        Buffer.from([0x4D, 0x02]),
+    ];
+    // Iterate over Image matrix
+    for (let x = 0; x < pixelMatrix.width; x++) {
+        // Each row has 3 bytes for command + 1 TIFF byte + 16 bytes for raster
+        let rowBuffer = Buffer.alloc(20);
+        // Raster Row Command
+        rowBuffer[0] = 0x47;
+        rowBuffer[1] = 0x11; // 17
+        rowBuffer[3] = 0x0F;
+        let margin = (options.tapeWidth === 12) ? 21 : 0;
+        for (let y = 0; y < pixelMatrix.height; y++) {
+            if (pixelMatrix.data[y][x] == 1) {
+                let byteNum = (Math.floor((y + margin) / 8) + 4); // 3 for command + 1 for TIFF compression length byte
+                let bitOffset = (y + margin) % 8;
+                rowBuffer[byteNum] |= (1 << 7 - bitOffset);
+            }
+        }
+        data.push(rowBuffer);
+    }
+    // Debugging
+    // data.map(row => console.log(row));
+    // Send print + cut command
+    data.push(Buffer.from([0x1A]));
+    return Buffer.concat(data);
+}
+function resolveOptions(options = {}) {
+    return Object.assign({ autoCut: true, blackwhiteThreshold: 128, halfCut: true, highResolution: false, tapeWidth: 12 }, options);
+}
+async function print(printerUrl, input, options) {
+    const resolvedOptions = resolveOptions(options);
+    const bufferToBePrinted = await convertToLabelBuffer(convertToBlackAndWhiteMatrix(input.type === 'buffer' ? await parse(input.data) : await parseFile(input.data), resolvedOptions.blackwhiteThreshold), resolvedOptions);
+    const printer = ipp_1.default.Printer(printerUrl);
+    const execute = node_util_1.default.promisify(printer.execute.bind(printer));
+    console.log('Checking printer status...');
+    const printerStatus = await execute('Get-Printer-Attributes', null);
+    if (printerStatus['printer-attributes-tag']['printer-state'] !== 'idle') {
+        throw new Error(`Printer ${printerStatus['printer-attributes-tag']['printer-name']} is not ready!`);
+    }
+    else {
+        console.log('Printer is ready.');
+    }
+    const res = await execute('Print-Job', {
+        'operation-attributes-tag': {
+            'requesting-user-name': 'mobile',
+            'job-name': 'label',
+            'document-format': 'application/octet-stream',
+        },
+        'job-attributes-tag': {
+            copies: 1,
+            sides: 'one-sided',
+            'orientation-requested': 'landscape',
+        },
+        data: bufferToBePrinted,
+    });
+    console.log('Print data sent.');
+    if (res.statusCode === 'successful-ok'
+        || res.statusCode === 'successful-ok-ignored-or-substituted-attributes') {
+        console.log('Printing successful.');
+        const jobId = res['job-attributes-tag']['job-id'];
+        let tries = 0;
+        let job;
+        await wait(500);
+        while (tries <= 50) {
+            tries += 1;
+            job = await execute('Get-Job-Attributes', { 'operation-attributes-tag': { 'job-id': jobId } });
+            if (job && job['job-attributes-tag']['job-state'] === 'completed') {
+                return job;
+            }
+            await wait(1000);
+        }
+        await execute('Cancel-Job', {
+            'operation-attributes-tag': {
+                'printer-uri': printer.uri, // or uncomment this two lines - one of variants should work!!!
+                'job-id': job['job-attributes-tag']['job-id'],
+            },
+        });
+        console.log(`Job with id ${job['job-attributes-tag']['job-id']}is being canceled`);
+        throw new Error('Job is canceled - too many tries and job is not printed!');
+    }
+    else {
+        console.log(res);
+        throw new Error('Error sending job to printer!');
+    }
+}
+const printPngFile = async function (printerUrl, filename, options = {}) {
+    return print(printerUrl, { type: 'file', data: filename }, options);
+};
+exports.printPngFile = printPngFile;
+const printBuffer = async function (printerUrl, buffer, options = {}) {
+    return print(printerUrl, { type: 'buffer', data: buffer }, options);
+};
+exports.printBuffer = printBuffer;

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
     "nodemon": "^2.0.12"
   },
   "scripts": {
-    "dev": "nodemon -L -w src src/index.ts",
+    "dev": "nodemon -L --watch src --exec ts-node src/brother.ts",
     "build": "tsc",
-    "start": "ts-node src/index.ts"
+    "start": "ts-node src/brother.ts",
+    "test": "NODE_PATH=tests/mocks node --test tests"
   }
 }

--- a/tests/brother.test.js
+++ b/tests/brother.test.js
@@ -1,0 +1,40 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { printBuffer, printPngFile } from '../dist/brother.js';
+import * as ipp from './mocks/@sealsystems/ipp/index.js';
+import * as pngparse from './mocks/pngparse/index.js';
+
+test('printPngFile export exists', () => {
+  assert.equal(typeof printPngFile, 'function');
+});
+
+test('printBuffer export exists', () => {
+  assert.equal(typeof printBuffer, 'function');
+});
+
+test('printPngFile uses mocks to print a file', async () => {
+  ipp.calls.length = 0;
+  pngparse.files.length = 0;
+
+  const job = await printPngFile('http://localhost:631/ipp/print', 'file.png');
+
+  assert.deepEqual(pngparse.files, ['file.png']);
+  assert.equal(ipp.calls[0].operation, 'Get-Printer-Attributes');
+  assert.equal(ipp.calls[1].operation, 'Print-Job');
+  assert.equal(ipp.calls[2].operation, 'Get-Job-Attributes');
+  assert.equal(job['job-attributes-tag']['job-id'], 1);
+});
+
+test('printBuffer prints a supplied buffer', async () => {
+  ipp.calls.length = 0;
+  pngparse.files.length = 0;
+
+  const job = await printBuffer('http://localhost:631/ipp/print', Buffer.from([1]));
+
+  assert.deepEqual(pngparse.files, ['<buffer>']);
+  assert.equal(ipp.calls[0].operation, 'Get-Printer-Attributes');
+  assert.equal(ipp.calls[1].operation, 'Print-Job');
+  assert(ipp.calls[1].args.data instanceof Buffer);
+  assert.equal(ipp.calls[2].operation, 'Get-Job-Attributes');
+  assert.equal(job['job-attributes-tag']['job-id'], 1);
+});

--- a/tests/mocks/@sealsystems/ipp/index.js
+++ b/tests/mocks/@sealsystems/ipp/index.js
@@ -1,0 +1,21 @@
+const calls = [];
+
+exports.calls = calls;
+exports.Printer = () => ({
+  execute(operation, args, callback) {
+    calls.push({ operation, args });
+
+    let result;
+    if (operation === 'Get-Printer-Attributes') {
+      result = { 'printer-attributes-tag': { 'printer-state': 'idle', 'printer-name': 'MockPrinter' } };
+    } else if (operation === 'Print-Job') {
+      result = { statusCode: 'successful-ok', 'job-attributes-tag': { 'job-id': 1 } };
+    } else if (operation === 'Get-Job-Attributes') {
+      result = { 'job-attributes-tag': { 'job-state': 'completed', 'job-id': 1 } };
+    } else {
+      result = null;
+    }
+
+    callback(null, result);
+  },
+});

--- a/tests/mocks/pngparse/index.js
+++ b/tests/mocks/pngparse/index.js
@@ -1,0 +1,16 @@
+const files = [];
+
+exports.files = files;
+
+function parseFile(name, cb) {
+  files.push(name);
+  cb(null, { width: 1, height: 1, channels: 1, data: Uint8Array.from([0]) });
+}
+
+function parse(buffer, cb) {
+  files.push('<buffer>');
+  cb(null, { width: 1, height: 1, channels: 1, data: Uint8Array.from([0]) });
+}
+
+exports.parseFile = parseFile;
+exports.parse = parse;


### PR DESCRIPTION
## Summary
- add compiled dist output so tests run without a build step
- extend IPP and pngparse mocks to support callback API and track calls
- verify printBuffer and printPngFile via new unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fbdccf89c8326ae71908c2e44ed26